### PR TITLE
📝 Add METADATA.yaml for working group visibility on amp.dev

### DIFF
--- a/METADATA.yaml
+++ b/METADATA.yaml
@@ -4,14 +4,16 @@ facilitator:
   login: newmuis
   name: Jon Newmuis
 members:
+  - login: jackbsteinberg
+    name: Jack Steinberg
   - login: gmajoulet
     name: Gabriel Majoulet
-  - login: enriqe
+  - login: Enriqe
     name: Enrique Marroquin
-  - login: bramanudom
-    name: Pet Ramanudom
   - login: vinaymahag
     name: Vinay Mahagaokar
+  - login: jasti
+    name: Vamsee Jasti
   - login: hongwei1990
     name: Wei Hong
 communication:

--- a/METADATA.yaml
+++ b/METADATA.yaml
@@ -1,0 +1,27 @@
+title: Stories
+description: The wg-stories Working Group is responsible for implementing and improving AMP's story format (amp-story).
+facilitator:
+  login: newmuis
+  name: Jon Newmuis
+members:
+  - login: gmajoulet
+    name: Gabriel Majoulet
+  - login: enriqe
+    name: Enrique Marroquin
+  - login: bramanudom
+    name: Pet Ramanudom
+  - login: vinaymahag
+    name: Vinay Mahagaokar
+  - login: hongwei1990
+    name: Wei Hong
+communication:
+  - channel: slack
+    name: Slack
+    content:
+      - item: "The Stories Working Group members will use `#wg-stories` channel on AMP's Slack ([signup](https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877)) for real-time discussion. The channel is open to anyone, regardless of membership in Stories working group."
+  - channel: github
+    name: GitHub
+    content:
+      - item: "Stories Working Group will post **Status Updates** every two weeks as an issue labeled with `Type: Status Update` in this repository."
+      - item: "Stories Working Group will post **Announcements and Notices** regarding events as an issue labeled with `Type: Event` in this repository."
+      - item: "Stories Working Group will post **Quarterly Roadmap** as an issue labeled with `Type: Roadmap` in this repository."


### PR DESCRIPTION
This is part of the effort of making the AMP Project working groups more visible. By adding a METADATA.yaml file to this repository relevant information about the working group (facilitator, team members, channels, etc.) is easily importable by amp.dev's build process and makes it possible to build an AMP page for each working group.

See ampproject/amp.dev#1699 and ampproject/amp.dev#3065 for more history.

/cc @pbakaus, @sebastianbenz